### PR TITLE
[APPC 1035] Fix returned bundle in the Installation dialog setResult

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import com.appcoins.sdk.android.billing.BuildConfig;
 import com.appcoins.sdk.android.billing.R;
 import com.appcoins.sdk.billing.helpers.InstallDialogActivity;
+import com.appcoins.sdk.billing.helpers.Utils;
 import com.appcoins.sdk.billing.helpers.WalletUtils;
 
 import static android.graphics.Typeface.BOLD;
@@ -141,7 +142,13 @@ public class DialogWalletInstall extends Dialog {
         redirectToStore();
         DialogWalletInstall.this.dismiss();
         if (mContext instanceof InstallDialogActivity) {
-          ((Activity) mContext).setResult(RESULT_USER_CANCELED);
+          Bundle response = new Bundle();
+          response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
+
+          Intent intent = new Intent();
+          intent.putExtras(response);
+
+          ((Activity) mContext).setResult(Activity.RESULT_CANCELED, intent);
           ((Activity) mContext).finish();
         }
       }
@@ -154,7 +161,13 @@ public class DialogWalletInstall extends Dialog {
       @Override public void onClick(View v) {
         DialogWalletInstall.this.dismiss();
         if (mContext instanceof InstallDialogActivity) {
-          ((Activity) mContext).setResult(RESULT_USER_CANCELED);
+          Bundle response = new Bundle();
+          response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
+
+          Intent intent = new Intent();
+          intent.putExtras(response);
+
+          ((Activity) mContext).setResult(Activity.RESULT_CANCELED, intent);
           ((Activity) mContext).finish();
         }
       }


### PR DESCRIPTION
-Bug fix in DialogInstall that was sending wrong response codes.


**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1035](https://aptoide.atlassian.net/browse/APPC-1035)




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass