### PR TITLE
feature/APPC-1391-update-resources-loading-process-on-installation-dialog

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -76,8 +76,6 @@ public class DialogWalletInstall extends Dialog {
 
     requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-    setContentView(contextApp.getResources()
-        .getIdentifier("wallet_install_dialog", "layout", contextApp.getPackageName()));
     setContentView(appContext.getResources()
         .getIdentifier("wallet_install_dialog", "layout", appContext.getPackageName()));
     setCancelable(false);

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -101,24 +101,29 @@ public class DialogWalletInstall extends Dialog {
       }
     });
 
+    //dialog_wallet_install_has_image
     hasImage = getContext().getResources()
         .getBoolean(R.bool.dialog_wallet_install_has_image) && icon != null;
 
-    if (hasImage) {
+    if (!hasImage) {
       dialog_wallet_install_image_icon.setVisibility(View.INVISIBLE);
       RelativeLayout.LayoutParams lp =
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(124));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
-      dialog_wallet_install_image_graphic.setImageDrawable(
-          getContext().getDrawable(R.drawable.dialog_wallet_install_graphic));
+      int resourceId = contextApp.getResources()
+          .getIdentifier("dialog_wallet_install_graphic", "drawable", contextApp.getPackageName());
+      dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
+          .getDrawable(resourceId));
     } else {
       dialog_wallet_install_image_icon.setVisibility(View.VISIBLE);
       dialog_wallet_install_image_icon.setImageDrawable(icon);
       RelativeLayout.LayoutParams lp =
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(100));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
-      dialog_wallet_install_image_graphic.setImageDrawable(
-          getContext().getDrawable(R.drawable.dialog_wallet_install_empty_image));
+      int resourceId = contextApp.getResources()
+          .getIdentifier("dialog_wallet_install_empty_image", "drawable", contextApp.getPackageName());
+      dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
+          .getDrawable(resourceId));
     }
   }
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -40,6 +40,14 @@ import static android.graphics.Typeface.BOLD;
  */
 public class DialogWalletInstall extends Dialog {
 
+  private static String DIALOG_WALLET_INSTALL_IMAGE_ICON = "dialog_wallet_install_image_icon";
+  private static String DIALOG_WALLET_INSTALL_IMAGE_GRAPHIC = "dialog_wallet_install_image_graphic";
+  private static String DIALOG_WALLET_INSTALL_GRAPHIC = "dialog_wallet_install_graphic";
+  private static String DIALOG_WALLET_INSTALL_EMPTY_IMAGE = "dialog_wallet_install_empty_image";
+  private static String DIALOG_WALLET_INSTALL_TEXT_MESSAGE = "dialog_wallet_install_text_message";
+  private static String DIALOG_WALLET_INSTALL_BUTTON_DOWNLOAD = "dialog_wallet_install_button_download";
+  private static String DIALOG_WALLET_INSTALL_BUTTON_CANCEL= "dialog_wallet_install_button_cancel";
+
   private Button dialog_wallet_install_button_cancel;
   private Button dialog_wallet_install_button_download;
   private TextView dialog_wallet_install_text_message;
@@ -89,10 +97,10 @@ public class DialogWalletInstall extends Dialog {
     }
 
     dialog_wallet_install_image_icon = findViewById(contextApp.getResources()
-        .getIdentifier("dialog_wallet_install_image_icon", "id", contextApp.getPackageName()));
+        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_ICON, "id", contextApp.getPackageName()));
 
     dialog_wallet_install_image_graphic = findViewById(contextApp.getResources()
-        .getIdentifier("dialog_wallet_install_image_graphic", "id", contextApp.getPackageName()));
+        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_GRAPHIC, "id", contextApp.getPackageName()));
 
     dialog_wallet_install_image_graphic.setOutlineProvider(new ViewOutlineProvider() {
       @Override public void getOutline(View view, Outline outline) {
@@ -101,17 +109,16 @@ public class DialogWalletInstall extends Dialog {
       }
     });
 
-    //dialog_wallet_install_has_image
     hasImage = getContext().getResources()
         .getBoolean(R.bool.dialog_wallet_install_has_image) && icon != null;
 
-    if (!hasImage) {
+    if (hasImage) {
       dialog_wallet_install_image_icon.setVisibility(View.INVISIBLE);
       RelativeLayout.LayoutParams lp =
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(124));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
       int resourceId = contextApp.getResources()
-          .getIdentifier("dialog_wallet_install_graphic", "drawable", contextApp.getPackageName());
+          .getIdentifier(DIALOG_WALLET_INSTALL_GRAPHIC, "drawable", contextApp.getPackageName());
       dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
           .getDrawable(resourceId));
     } else {
@@ -121,16 +128,16 @@ public class DialogWalletInstall extends Dialog {
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(100));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
       int resourceId = contextApp.getResources()
-          .getIdentifier("dialog_wallet_install_empty_image", "drawable", contextApp.getPackageName());
+          .getIdentifier(DIALOG_WALLET_INSTALL_EMPTY_IMAGE, "drawable",
+              contextApp.getPackageName());
       dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
           .getDrawable(resourceId));
     }
   }
 
   private void buildMessage() {
-    //R.id.dialog_wallet_install_text_message
     dialog_wallet_install_text_message = findViewById(contextApp.getResources()
-        .getIdentifier("dialog_wallet_install_text_message", "id", contextApp.getPackageName()));
+        .getIdentifier(DIALOG_WALLET_INSTALL_TEXT_MESSAGE, "id", contextApp.getPackageName()));
 
     String dialog_message = getContext().getString(R.string.app_wallet_install_wallet_from_iab);
 
@@ -143,9 +150,8 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void buildDownloadButton() {
-    //R.id.dialog_wallet_install_button_download
     dialog_wallet_install_button_download = findViewById(contextApp.getResources()
-        .getIdentifier("dialog_wallet_install_button_download", "id", contextApp.getPackageName()));
+        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_DOWNLOAD, "id", contextApp.getPackageName()));
     dialog_wallet_install_button_download.setOnClickListener(new View.OnClickListener() {
 
       @Override public void onClick(View v) {
@@ -166,9 +172,8 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void buildCancelButton() {
-    //dialog_wallet_install_button_download
     dialog_wallet_install_button_cancel = findViewById(contextApp.getResources()
-        .getIdentifier("dialog_wallet_install_button_download", "id", contextApp.getPackageName()));
+        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_CANCEL, "id", contextApp.getPackageName()));
     dialog_wallet_install_button_cancel.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         DialogWalletInstall.this.dismiss();
@@ -187,7 +192,6 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void redirectToStore() {
-    //https://developer.android.com/distribute/marketing-tools/linking-to-google-play
     getContext().startActivity(buildStoreViewIntent(URL_APTOIDE));
   }
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -51,10 +51,10 @@ public class DialogWalletInstall extends Dialog {
       + BuildConfig.BDS_WALLET_PACKAGE_NAME
       + "&utm_source=appcoinssdk&app_source="
       + getContext().getPackageName();
-  private static Context mContext;
+  private static Context contextApp;
 
   public static DialogWalletInstall with(Context context) {
-    mContext = context;
+    contextApp = context;
     return new DialogWalletInstall(context);
   }
 
@@ -68,7 +68,8 @@ public class DialogWalletInstall extends Dialog {
 
     requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-    setContentView(R.layout.wallet_install_dialog);
+    setContentView(contextApp.getResources()
+        .getIdentifier("wallet_install_dialog", "layout", contextApp.getPackageName()));
     setCancelable(false);
 
     buildTop();
@@ -81,15 +82,17 @@ public class DialogWalletInstall extends Dialog {
     boolean hasImage;
     Drawable icon = null;
     try {
-      icon = mContext.getPackageManager()
-          .getApplicationIcon(mContext.getPackageName());
+      icon = contextApp.getPackageManager()
+          .getApplicationIcon(contextApp.getPackageName());
     } catch (PackageManager.NameNotFoundException e) {
       e.printStackTrace();
     }
 
-    dialog_wallet_install_image_icon = findViewById(R.id.dialog_wallet_install_image_icon);
+    dialog_wallet_install_image_icon = findViewById(contextApp.getResources()
+        .getIdentifier("dialog_wallet_install_image_icon", "id", contextApp.getPackageName()));
 
-    dialog_wallet_install_image_graphic = findViewById(R.id.dialog_wallet_install_image_graphic);
+    dialog_wallet_install_image_graphic = findViewById(contextApp.getResources()
+        .getIdentifier("dialog_wallet_install_image_graphic", "id", contextApp.getPackageName()));
 
     dialog_wallet_install_image_graphic.setOutlineProvider(new ViewOutlineProvider() {
       @Override public void getOutline(View view, Outline outline) {
@@ -120,7 +123,10 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void buildMessage() {
-    dialog_wallet_install_text_message = findViewById(R.id.dialog_wallet_install_text_message);
+    //R.id.dialog_wallet_install_text_message
+    dialog_wallet_install_text_message = findViewById(contextApp.getResources()
+        .getIdentifier("dialog_wallet_install_text_message", "id", contextApp.getPackageName()));
+
     String dialog_message = getContext().getString(R.string.app_wallet_install_wallet_from_iab);
 
     SpannableStringBuilder messageStylized = new SpannableStringBuilder(dialog_message);
@@ -132,41 +138,44 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void buildDownloadButton() {
-    dialog_wallet_install_button_download =
-        findViewById(R.id.dialog_wallet_install_button_download);
+    //R.id.dialog_wallet_install_button_download
+    dialog_wallet_install_button_download = findViewById(contextApp.getResources()
+        .getIdentifier("dialog_wallet_install_button_download", "id", contextApp.getPackageName()));
     dialog_wallet_install_button_download.setOnClickListener(new View.OnClickListener() {
 
       @Override public void onClick(View v) {
         redirectToStore();
         DialogWalletInstall.this.dismiss();
-        if (mContext instanceof InstallDialogActivity) {
+        if (contextApp instanceof InstallDialogActivity) {
           Bundle response = new Bundle();
           response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
 
           Intent intent = new Intent();
           intent.putExtras(response);
 
-          ((Activity) mContext).setResult(Activity.RESULT_CANCELED, intent);
-          ((Activity) mContext).finish();
+          ((Activity) contextApp).setResult(Activity.RESULT_CANCELED, intent);
+          ((Activity) contextApp).finish();
         }
       }
     });
   }
 
   private void buildCancelButton() {
-    dialog_wallet_install_button_cancel = findViewById(R.id.dialog_wallet_install_button_cancel);
+    //dialog_wallet_install_button_download
+    dialog_wallet_install_button_cancel = findViewById(contextApp.getResources()
+        .getIdentifier("dialog_wallet_install_button_download", "id", contextApp.getPackageName()));
     dialog_wallet_install_button_cancel.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         DialogWalletInstall.this.dismiss();
-        if (mContext instanceof InstallDialogActivity) {
+        if (contextApp instanceof InstallDialogActivity) {
           Bundle response = new Bundle();
           response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
 
           Intent intent = new Intent();
           intent.putExtras(response);
 
-          ((Activity) mContext).setResult(Activity.RESULT_CANCELED, intent);
-          ((Activity) mContext).finish();
+          ((Activity) contextApp).setResult(Activity.RESULT_CANCELED, intent);
+          ((Activity) contextApp).finish();
         }
       }
     });

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -59,10 +59,10 @@ public class DialogWalletInstall extends Dialog {
       + BuildConfig.BDS_WALLET_PACKAGE_NAME
       + "&utm_source=appcoinssdk&app_source="
       + getContext().getPackageName();
-  private static Context contextApp;
+  private static Context appContext;
 
   public static DialogWalletInstall with(Context context) {
-    contextApp = context;
+    appContext = context;
     return new DialogWalletInstall(context);
   }
 
@@ -78,6 +78,8 @@ public class DialogWalletInstall extends Dialog {
 
     setContentView(contextApp.getResources()
         .getIdentifier("wallet_install_dialog", "layout", contextApp.getPackageName()));
+    setContentView(appContext.getResources()
+        .getIdentifier("wallet_install_dialog", "layout", appContext.getPackageName()));
     setCancelable(false);
 
     buildTop();
@@ -90,17 +92,17 @@ public class DialogWalletInstall extends Dialog {
     boolean hasImage;
     Drawable icon = null;
     try {
-      icon = contextApp.getPackageManager()
-          .getApplicationIcon(contextApp.getPackageName());
+      icon = appContext.getPackageManager()
+          .getApplicationIcon(appContext.getPackageName());
     } catch (PackageManager.NameNotFoundException e) {
       e.printStackTrace();
     }
 
-    dialog_wallet_install_image_icon = findViewById(contextApp.getResources()
-        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_ICON, "id", contextApp.getPackageName()));
+    dialog_wallet_install_image_icon = findViewById(appContext.getResources()
+        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_ICON, "id", appContext.getPackageName()));
 
-    dialog_wallet_install_image_graphic = findViewById(contextApp.getResources()
-        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_GRAPHIC, "id", contextApp.getPackageName()));
+    dialog_wallet_install_image_graphic = findViewById(appContext.getResources()
+        .getIdentifier(DIALOG_WALLET_INSTALL_IMAGE_GRAPHIC, "id", appContext.getPackageName()));
 
     dialog_wallet_install_image_graphic.setOutlineProvider(new ViewOutlineProvider() {
       @Override public void getOutline(View view, Outline outline) {
@@ -117,9 +119,9 @@ public class DialogWalletInstall extends Dialog {
       RelativeLayout.LayoutParams lp =
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(124));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
-      int resourceId = contextApp.getResources()
-          .getIdentifier(DIALOG_WALLET_INSTALL_GRAPHIC, "drawable", contextApp.getPackageName());
-      dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
+      int resourceId = appContext.getResources()
+          .getIdentifier(DIALOG_WALLET_INSTALL_GRAPHIC, "drawable", appContext.getPackageName());
+      dialog_wallet_install_image_graphic.setImageDrawable(appContext.getResources()
           .getDrawable(resourceId));
     } else {
       dialog_wallet_install_image_icon.setVisibility(View.VISIBLE);
@@ -127,17 +129,17 @@ public class DialogWalletInstall extends Dialog {
       RelativeLayout.LayoutParams lp =
           new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(100));
       dialog_wallet_install_image_graphic.setLayoutParams(lp);
-      int resourceId = contextApp.getResources()
+      int resourceId = appContext.getResources()
           .getIdentifier(DIALOG_WALLET_INSTALL_EMPTY_IMAGE, "drawable",
-              contextApp.getPackageName());
-      dialog_wallet_install_image_graphic.setImageDrawable(contextApp.getResources()
+              appContext.getPackageName());
+      dialog_wallet_install_image_graphic.setImageDrawable(appContext.getResources()
           .getDrawable(resourceId));
     }
   }
 
   private void buildMessage() {
-    dialog_wallet_install_text_message = findViewById(contextApp.getResources()
-        .getIdentifier(DIALOG_WALLET_INSTALL_TEXT_MESSAGE, "id", contextApp.getPackageName()));
+    dialog_wallet_install_text_message = findViewById(appContext.getResources()
+        .getIdentifier(DIALOG_WALLET_INSTALL_TEXT_MESSAGE, "id", appContext.getPackageName()));
 
     String dialog_message = getContext().getString(R.string.app_wallet_install_wallet_from_iab);
 
@@ -150,42 +152,42 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private void buildDownloadButton() {
-    dialog_wallet_install_button_download = findViewById(contextApp.getResources()
-        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_DOWNLOAD, "id", contextApp.getPackageName()));
+    dialog_wallet_install_button_download = findViewById(appContext.getResources()
+        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_DOWNLOAD, "id", appContext.getPackageName()));
     dialog_wallet_install_button_download.setOnClickListener(new View.OnClickListener() {
 
       @Override public void onClick(View v) {
         redirectToStore();
         DialogWalletInstall.this.dismiss();
-        if (contextApp instanceof InstallDialogActivity) {
+        if (appContext instanceof InstallDialogActivity) {
           Bundle response = new Bundle();
           response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
 
           Intent intent = new Intent();
           intent.putExtras(response);
 
-          ((Activity) contextApp).setResult(Activity.RESULT_CANCELED, intent);
-          ((Activity) contextApp).finish();
+          ((Activity) appContext).setResult(Activity.RESULT_CANCELED, intent);
+          ((Activity) appContext).finish();
         }
       }
     });
   }
 
   private void buildCancelButton() {
-    dialog_wallet_install_button_cancel = findViewById(contextApp.getResources()
-        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_CANCEL, "id", contextApp.getPackageName()));
+    dialog_wallet_install_button_cancel = findViewById(appContext.getResources()
+        .getIdentifier(DIALOG_WALLET_INSTALL_BUTTON_CANCEL, "id", appContext.getPackageName()));
     dialog_wallet_install_button_cancel.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         DialogWalletInstall.this.dismiss();
-        if (contextApp instanceof InstallDialogActivity) {
+        if (appContext instanceof InstallDialogActivity) {
           Bundle response = new Bundle();
           response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
 
           Intent intent = new Intent();
           intent.putExtras(response);
 
-          ((Activity) contextApp).setResult(Activity.RESULT_CANCELED, intent);
-          ((Activity) contextApp).finish();
+          ((Activity) appContext).setResult(Activity.RESULT_CANCELED, intent);
+          ((Activity) appContext).finish();
         }
       }
     });


### PR DESCRIPTION
**What does this PR do?**

- Changed how the way the resources are loaded.Instead of being load by the ID they are load by name.

**Database changed?**

 No

**Where should the reviewer start?**

- DialogWalletInstall.java

**How should this be manually tested?**

- Try to buy Gas withtouth having the Wallet install.
- Install the Wallet.
- Make the purchase
  Flow on how to test this or QA Tickets related to this use-case: [APPC-1391](https://aptoide.atlassian.net/browse/APPC-1391)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1391](https://aptoide.atlassian.net/browse/APPC-1391)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 

no


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass