### PR TITLE
APPC-1391-Removed the remaining calls to R directly

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -113,7 +113,7 @@ public class DialogWalletInstall extends Dialog {
 
     hasImage = getContext().getResources()
         .getBoolean(appContext.getResources()
-            .getIdentifier(DIALOG_WALLET_INSTALL_HAS_IMAGE, "id",
+            .getIdentifier(DIALOG_WALLET_INSTALL_HAS_IMAGE, "bool",
                 appContext.getPackageName())) && icon != null;
 
     if (hasImage) {
@@ -144,7 +144,7 @@ public class DialogWalletInstall extends Dialog {
         .getIdentifier(DIALOG_WALLET_INSTALL_TEXT_MESSAGE, "id", appContext.getPackageName()));
 
     String dialog_message = getContext().getString(appContext.getResources()
-        .getIdentifier(APP_WALLET_INSTALL_WALLET_FROM_IAB, "id", appContext.getPackageName()));
+        .getIdentifier(APP_WALLET_INSTALL_WALLET_FROM_IAB, "string", appContext.getPackageName()));
 
     SpannableStringBuilder messageStylized = new SpannableStringBuilder(dialog_message);
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -47,6 +47,8 @@ public class DialogWalletInstall extends Dialog {
   private static String DIALOG_WALLET_INSTALL_TEXT_MESSAGE = "dialog_wallet_install_text_message";
   private static String DIALOG_WALLET_INSTALL_BUTTON_DOWNLOAD = "dialog_wallet_install_button_download";
   private static String DIALOG_WALLET_INSTALL_BUTTON_CANCEL= "dialog_wallet_install_button_cancel";
+  private static String APP_WALLET_INSTALL_WALLET_FROM_IAB = "app_wallet_install_wallet_from_iab";
+  private static String DIALOG_WALLET_INSTALL_HAS_IMAGE = "dialog_wallet_install_has_image";
 
   private Button dialog_wallet_install_button_cancel;
   private Button dialog_wallet_install_button_download;
@@ -110,7 +112,9 @@ public class DialogWalletInstall extends Dialog {
     });
 
     hasImage = getContext().getResources()
-        .getBoolean(R.bool.dialog_wallet_install_has_image) && icon != null;
+        .getBoolean(appContext.getResources()
+            .getIdentifier(DIALOG_WALLET_INSTALL_HAS_IMAGE, "id",
+                appContext.getPackageName())) && icon != null;
 
     if (hasImage) {
       dialog_wallet_install_image_icon.setVisibility(View.INVISIBLE);
@@ -139,7 +143,8 @@ public class DialogWalletInstall extends Dialog {
     dialog_wallet_install_text_message = findViewById(appContext.getResources()
         .getIdentifier(DIALOG_WALLET_INSTALL_TEXT_MESSAGE, "id", appContext.getPackageName()));
 
-    String dialog_message = getContext().getString(R.string.app_wallet_install_wallet_from_iab);
+    String dialog_message = getContext().getString(appContext.getResources()
+        .getIdentifier(APP_WALLET_INSTALL_WALLET_FROM_IAB, "id", appContext.getPackageName()));
 
     SpannableStringBuilder messageStylized = new SpannableStringBuilder(dialog_message);
 

--- a/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
+++ b/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
@@ -32,6 +32,9 @@ public class WalletUtils {
 
   private static boolean hasPopup;
 
+  private static String POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE = "poa_wallet_not_installed_notification_title";
+  private static String POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY = "poa_wallet_not_installed_notification_body";
+
   public static Context context;
 
   public static void setContext(Context cont) {
@@ -147,11 +150,15 @@ public class WalletUtils {
     builder = new Notification.Builder(context, channelId);
     builder.setContentIntent(pendingIntent);
     try {
+      Resources resources = context.getResources();
+      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"id",context.getPackageName());
+      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"id",context.getPackageName());
+
       builder.setSmallIcon(intent.getExtras()
           .getInt("identifier"))
           .setAutoCancel(true)
-          .setContentTitle(context.getString(R.string.poa_wallet_not_installed_notification_title))
-          .setContentText(context.getString(R.string.poa_wallet_not_installed_notification_body));
+          .setContentTitle(context.getString(titleId))
+          .setContentText(context.getString(bodyId));
     } catch (NullPointerException e) {
       e.printStackTrace();
     }
@@ -169,11 +176,15 @@ public class WalletUtils {
     builder.setVibrate(new long[0]);
 
     try {
+      Resources resources = context.getResources();
+      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"id",context.getPackageName());
+      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"id",context.getPackageName());
+
       builder.setSmallIcon(intent.getExtras()
           .getInt("identifier"))
           .setAutoCancel(true)
-          .setContentTitle(context.getString(R.string.poa_wallet_not_installed_notification_title))
-          .setContentText(context.getString(R.string.poa_wallet_not_installed_notification_body));
+          .setContentTitle(context.getString(titleId))
+          .setContentText(context.getString(bodyId));
     } catch (NullPointerException e) {
       e.printStackTrace();
     }

--- a/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
+++ b/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
@@ -151,8 +151,8 @@ public class WalletUtils {
     builder.setContentIntent(pendingIntent);
     try {
       Resources resources = context.getResources();
-      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"id",context.getPackageName());
-      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"id",context.getPackageName());
+      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"string",context.getPackageName());
+      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"string",context.getPackageName());
 
       builder.setSmallIcon(intent.getExtras()
           .getInt("identifier"))
@@ -177,8 +177,8 @@ public class WalletUtils {
 
     try {
       Resources resources = context.getResources();
-      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"id",context.getPackageName());
-      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"id",context.getPackageName());
+      int titleId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_TITLE,"string",context.getPackageName());
+      int bodyId = resources.getIdentifier(POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY,"string",context.getPackageName());
 
       builder.setSmallIcon(intent.getExtras()
           .getInt("identifier"))


### PR DESCRIPTION
**What does this PR do?**

Removes the remaining accesses to R directly (Unity's request)

**Database changed?**

No

**Where should the reviewer start?**

- [x] WalletUtils.java
- [x] DialogWalletInstall.java

**How should this be manually tested?**

No need

**What are the relevant tickets?**
APPC-1391
https://aptoide.atlassian.net/browse/APPC-1391

**Questions:**

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass