### PR TITLE
Bugfix/APPC-1250-Update-logic-to-open-Aptoide-when-wallet-no-installed

### DIFF
--- a/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
+++ b/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
@@ -30,7 +30,7 @@ public class WalletUtils {
   private static int UNINSTALLED_APTOIDE_VERSION_CODE = 0;
 
   private static String URL_INTENT_INSTALL =
-      "market://details?id=com.appcoins.wallet&utm_source=appcoinssdk&app_source=";
+      "market://details?id="+BuildConfig.BDS_WALLET_PACKAGE_NAME+"&utm_source=appcoinssdk&app_source=";
 
   private static String URL_APTOIDE_PARAMETERS = "&utm_source=appcoinssdk&app_source=";
 
@@ -146,8 +146,8 @@ public class WalletUtils {
 
   private static Intent getNotificationIntent() {
     String url = URL_INTENT_INSTALL;
-
-    if (WalletUtils.getAptoideVersion() != UNINSTALLED_APTOIDE_VERSION_CODE) {
+    int verCode = WalletUtils.getAptoideVersion();
+    if ( verCode != UNINSTALLED_APTOIDE_VERSION_CODE) {
       url += URL_APTOIDE_PARAMETERS + context.getPackageName();
     }
 
@@ -155,7 +155,7 @@ public class WalletUtils {
     intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
-    if (WalletUtils.getAptoideVersion() >= MINIMUM_APTOIDE_VERSION) {
+    if (verCode >= MINIMUM_APTOIDE_VERSION) {
       intent.setPackage(BuildConfig.APTOIDE_PACKAGE_NAME);
     }
 


### PR DESCRIPTION

**What does this PR do?**

https://aptoide.atlassian.net/browse/APPC-1250
 - Changed a static url to include the package name of the build type
- Optimize some code


**Database changed?**

 No

**Where should the reviewer start?**

com.asf.appcoins.sdk.ads.poa.manager.WalletUtils.java;

**How should this be manually tested?**

Case 1:
- Have Aptoide dev version bigger or equal than 9.8.00.
- Have no wallet installed.
- On startup click on the POA notification
- Should be redirected to Aptoide page where package not found.

Case 2:

- Have Aptoide dev version smaller than 9.8.00.
- Have no wallet installed.
- On startup click on the POA notification
- Should open the store options.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1250](https://aptoide.atlassian.net/browse/APPC-1250)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1250](https://aptoide.atlassian.net/browse/APPC-1250)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 

no


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass