### PR TITLE
bugfix/udp-no-stores-installed-and-getPackageName-migrator-problem

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/WalletUtils.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/WalletUtils.java
@@ -1,6 +1,5 @@
 package com.appcoins.sdk.billing.helpers;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -23,12 +22,17 @@ public class WalletUtils {
   }
 
   public static boolean hasWalletInstalled() {
+    if (billingPackageName == null) {
+      getPackageToBind();
+    }
+    return billingPackageName != null;
+  }
 
+  private static void getPackageToBind() {
     ArrayList intentServicesResponse = new ArrayList();
     Intent serviceIntent = new Intent(BuildConfig.IAB_BIND_ACTION);
 
-    List<ResolveInfo> intentServices = context
-        .getPackageManager()
+    List<ResolveInfo> intentServices = context.getPackageManager()
         .queryIntentServices(serviceIntent, 0);
 
     if (intentServices != null && intentServices.size() > 0) {
@@ -37,7 +41,6 @@ public class WalletUtils {
       }
       billingPackageName = chooseServiceToBind(intentServicesResponse);
     }
-    return billingPackageName != null;
   }
 
   private static String chooseServiceToBind(ArrayList packageNameServices) {
@@ -56,8 +59,7 @@ public class WalletUtils {
     int versionCode = UNINSTALLED_APTOIDE_VERSION_CODE;
 
     try {
-      pInfo = context
-          .getPackageManager()
+      pInfo = context.getPackageManager()
           .getPackageInfo(BuildConfig.APTOIDE_PACKAGE_NAME, 0);
 
       //VersionCode is deprecated for api 28
@@ -78,6 +80,9 @@ public class WalletUtils {
   }
 
   public static String getBillingServicePackageName() {
+    if (billingPackageName == null) {
+      getPackageToBind();
+    }
     return billingPackageName;
   }
 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -2,8 +2,10 @@ package com.appcoins.sdk.billing.wallet;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.Outline;
@@ -63,6 +65,10 @@ public class DialogWalletInstall extends Dialog {
       + BuildConfig.BDS_WALLET_PACKAGE_NAME
       + "&utm_source=appcoinssdk&app_source="
       + getContext().getPackageName();
+
+  private final String URL_BROWSER =
+      "https://play.google.com/store/apps/details?id=" + BuildConfig.BDS_WALLET_PACKAGE_NAME;
+
   private static Context appContext;
 
   public static DialogWalletInstall with(Context context) {
@@ -168,7 +174,15 @@ public class DialogWalletInstall extends Dialog {
     dialog_wallet_install_button_download.setOnClickListener(new View.OnClickListener() {
 
       @Override public void onClick(View v) {
-        redirectToStore();
+        Intent storeIntent = buildStoreViewIntent();
+        if (resolveActivityInfoForIntent(storeIntent)) {
+          getContext().startActivity(storeIntent);
+        } else {
+          Intent browserIntent = buildBrowserIntent();
+          if (resolveActivityInfoForIntent(browserIntent)) {
+            getContext().startActivity(browserIntent);
+          }
+        }
       }
     });
   }
@@ -193,12 +207,18 @@ public class DialogWalletInstall extends Dialog {
     });
   }
 
-  private void redirectToStore() {
-    getContext().startActivity(buildStoreViewIntent(URL_APTOIDE));
+  private boolean resolveActivityInfoForIntent(Intent intent) {
+      ActivityInfo activityInfo = intent.resolveActivityInfo(getContext().getPackageManager(), 0);
+    return activityInfo != null;
   }
 
-  private Intent buildStoreViewIntent(String action) {
-    final Intent appStoreIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(action));
+  private Intent buildBrowserIntent() {
+    Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(URL_BROWSER));
+    return browserIntent;
+  }
+
+  private Intent buildStoreViewIntent() {
+    final Intent appStoreIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(URL_APTOIDE));
     if (WalletUtils.getAptoideVersion() >= MINIMUM_APTOIDE_VERSION) {
       appStoreIntent.setPackage(BuildConfig.APTOIDE_PACKAGE_NAME);
     }

--- a/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
+++ b/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
@@ -120,7 +120,7 @@ public class WalletUtils {
 
   private static boolean resolveActivityInfoForIntent(Intent intent) {
     ActivityInfo activityInfo = intent.resolveActivityInfo(context.getPackageManager(), 0);
-    return activityInfo != null;
+    return activityInfo == null;
   }
 
   public static void removeNotification() {
@@ -134,9 +134,9 @@ public class WalletUtils {
 
     Intent intent = getNotificationIntentForStore();
 
-    if (!resolveActivityInfoForIntent(intent)) {
+    if (resolveActivityInfoForIntent(intent)) {
       intent = getNotificationIntentForBrowser();
-      if (!resolveActivityInfoForIntent(intent)) {
+      if (resolveActivityInfoForIntent(intent)) {
         intent = null;
       }
     }
@@ -169,7 +169,7 @@ public class WalletUtils {
   }
 
   private static Intent getNotificationIntentForBrowser() {
-    Intent intent = null;
+    Intent intent;
     intent = new Intent(Intent.ACTION_VIEW, Uri.parse(URL_BROWSER));
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
     return buildNotification(intent);
@@ -183,7 +183,7 @@ public class WalletUtils {
       url += URL_APTOIDE_PARAMETERS + context.getPackageName();
     }
 
-    Intent intent = null;
+    Intent intent;
     intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 

--- a/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
+++ b/appcoins-ads/src/main/java/com/asf/appcoins/sdk/ads/poa/manager/WalletUtils.java
@@ -6,6 +6,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -15,9 +16,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 import com.asf.appcoins.sdk.ads.BuildConfig;
-import java.util.List;
 import java.util.ArrayList;
-
+import java.util.List;
 
 public class WalletUtils {
 
@@ -29,8 +29,9 @@ public class WalletUtils {
 
   private static int UNINSTALLED_APTOIDE_VERSION_CODE = 0;
 
-  private static String URL_INTENT_INSTALL =
-      "market://details?id="+BuildConfig.BDS_WALLET_PACKAGE_NAME+"&utm_source=appcoinssdk&app_source=";
+  private static String URL_INTENT_INSTALL = "market://details?id="
+      + BuildConfig.BDS_WALLET_PACKAGE_NAME
+      + "&utm_source=appcoinssdk&app_source=";
 
   private static String URL_APTOIDE_PARAMETERS = "&utm_source=appcoinssdk&app_source=";
 
@@ -45,6 +46,9 @@ public class WalletUtils {
   private static String POA_WALLET_NOT_INSTALLED_NOTIFICATION_BODY =
       "poa_wallet_not_installed_notification_body";
 
+  private static final String URL_BROWSER = "https://play.google.com/store/apps/details?id="
+      + com.appcoins.billing.sdk.BuildConfig.BDS_WALLET_PACKAGE_NAME;
+
   public static Context context;
 
   public static String billingPackageName;
@@ -54,20 +58,25 @@ public class WalletUtils {
   }
 
   public static boolean hasWalletInstalled() {
-    ArrayList <String> intentServicesResponse = new ArrayList<String>();
-    Intent serviceIntent = new Intent(BuildConfig.ADVERTISEMENT_BIND_ACTION);
+    if (billingPackageName == null) {
+      getPackageToBind();
+    }
+    return billingPackageName != null;
+  }
 
-    List<ResolveInfo> intentServices = context
-        .getPackageManager()
+  private static void getPackageToBind() {
+    ArrayList intentServicesResponse = new ArrayList();
+    Intent serviceIntent = new Intent(com.appcoins.billing.sdk.BuildConfig.IAB_BIND_ACTION);
+
+    List<ResolveInfo> intentServices = context.getPackageManager()
         .queryIntentServices(serviceIntent, 0);
 
-    if (intentServices.size() > 0 && intentServices != null) {
+    if (intentServices != null && intentServices.size() > 0) {
       for (ResolveInfo intentService : intentServices) {
         intentServicesResponse.add(intentService.serviceInfo.packageName);
       }
       billingPackageName = chooseServiceToBind(intentServicesResponse);
     }
-    return billingPackageName != null;
   }
 
   private static String chooseServiceToBind(ArrayList packageNameServices) {
@@ -81,6 +90,9 @@ public class WalletUtils {
   }
 
   public static String getBillingServicePackageName() {
+    if (billingPackageName == null) {
+      getPackageToBind();
+    }
     return billingPackageName;
   }
 
@@ -106,6 +118,11 @@ public class WalletUtils {
     return versionCode;
   }
 
+  private static boolean resolveActivityInfoForIntent(Intent intent) {
+    ActivityInfo activityInfo = intent.resolveActivityInfo(context.getPackageManager(), 0);
+    return activityInfo != null;
+  }
+
   public static void removeNotification() {
     if (hasPopup) {
       notificationManager.cancel(POA_NOTIFICATION_ID);
@@ -115,7 +132,14 @@ public class WalletUtils {
 
   public static void createInstallWalletNotification() {
 
-    Intent intent = getNotificationIntent();
+    Intent intent = getNotificationIntentForStore();
+
+    if (!resolveActivityInfoForIntent(intent)) {
+      intent = getNotificationIntentForBrowser();
+      if (!resolveActivityInfoForIntent(intent)) {
+        intent = null;
+      }
+    }
 
     if (intent == null) {
       return;
@@ -144,10 +168,18 @@ public class WalletUtils {
     }
   }
 
-  private static Intent getNotificationIntent() {
+  private static Intent getNotificationIntentForBrowser() {
+    Intent intent = null;
+    intent = new Intent(Intent.ACTION_VIEW, Uri.parse(URL_BROWSER));
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+    return buildNotification(intent);
+  }
+
+  private static Intent getNotificationIntentForStore() {
+
     String url = URL_INTENT_INSTALL;
     int verCode = WalletUtils.getAptoideVersion();
-    if ( verCode != UNINSTALLED_APTOIDE_VERSION_CODE) {
+    if (verCode != UNINSTALLED_APTOIDE_VERSION_CODE) {
       url += URL_APTOIDE_PARAMETERS + context.getPackageName();
     }
 
@@ -159,6 +191,10 @@ public class WalletUtils {
       intent.setPackage(BuildConfig.APTOIDE_PACKAGE_NAME);
     }
 
+    return buildNotification(intent);
+  }
+
+  private static Intent buildNotification(Intent intent) {
     PackageManager packageManager = context.getPackageManager();
     ApplicationInfo applicationInfo = null;
     Resources resources = null;


### PR DESCRIPTION
**What does this PR do?**

UDP Bug:
- When no stores installed now the intent is going to the browser
- This Change affects either POA and Billing.
Migrator:
-Changed the way the packageName to bind is retrieved.

**Database changed?**

 No

**Where should the reviewer start?**

WalletUtils.java -> android_appcoins_billing
WalletUtils.java -> appcoins_ads
DialogWalletInstall.java

**How should this be manually tested?**

- In a mobile phone with no stores installed and no wallet installed if the either the popup install and the notification redirects to browser.
-  In a mobile phone with Aptoide installed and no wallet installed if the either the popup install and the notification redirects to Aptoide.
- Make a purchase with after installing the wallet.
- Convert a POA after installing the wallet.
- Make a purchase when wallet is already installed
- Convert a POA  when wallet is already installed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1493](https://aptoide.atlassian.net/browse/APPC-1493)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 

No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass