### PR TITLE
Feature/appc 1518 create error dialog when there are no wallet or browser

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -1,9 +1,10 @@
 package com.appcoins.sdk.billing.wallet;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -52,6 +53,8 @@ public class DialogWalletInstall extends Dialog {
   private static String DIALOG_WALLET_INSTALL_BUTTON_CANCEL = "dialog_wallet_install_button_cancel";
   private static String APP_WALLET_INSTALL_WALLET_FROM_IAB = "app_wallet_install_wallet_from_iab";
   private static String DIALOG_WALLET_INSTALL_HAS_IMAGE = "dialog_wallet_install_has_image";
+  private static String DIALOG_NO_STORE_OR_BROWSER = "app_wallet_no_store_or_browser";
+  private static String APP_WALLET_SKIP = "app_wallet_skip";
 
   private Button dialog_wallet_install_button_cancel;
   private Button dialog_wallet_install_button_download;
@@ -181,6 +184,8 @@ public class DialogWalletInstall extends Dialog {
           Intent browserIntent = buildBrowserIntent();
           if (resolveActivityInfoForIntent(browserIntent)) {
             getContext().startActivity(browserIntent);
+          } else {
+            buildAlertNoBrowserAndStores();
           }
         }
       }
@@ -208,7 +213,7 @@ public class DialogWalletInstall extends Dialog {
   }
 
   private boolean resolveActivityInfoForIntent(Intent intent) {
-      ActivityInfo activityInfo = intent.resolveActivityInfo(getContext().getPackageManager(), 0);
+    ActivityInfo activityInfo = intent.resolveActivityInfo(getContext().getPackageManager(), 0);
     return activityInfo != null;
   }
 
@@ -231,5 +236,29 @@ public class DialogWalletInstall extends Dialog {
     DisplayMetrics displayMetrics = getContext().getResources()
         .getDisplayMetrics();
     return Math.round(pixels / (displayMetrics.xdpi / displayMetrics.densityDpi));
+  }
+
+  private void buildAlertNoBrowserAndStores() {
+    AlertDialog.Builder alert = new AlertDialog.Builder(appContext);
+    String value = appContext.getResources()
+        .getString(appContext.getResources()
+            .getIdentifier(DIALOG_NO_STORE_OR_BROWSER, "string", appContext.getPackageName()));
+    String dismissValue = appContext.getResources()
+        .getString(appContext.getResources()
+            .getIdentifier(APP_WALLET_SKIP, "string", appContext.getPackageName()));
+    alert.setMessage(value);
+    alert.setCancelable(true);
+    alert.setPositiveButton(dismissValue, new DialogInterface.OnClickListener() {
+      public void onClick(DialogInterface dialog, int id) {
+        Bundle response = new Bundle();
+        response.putInt(Utils.RESPONSE_CODE, RESULT_USER_CANCELED);
+        Intent intent = new Intent();
+        intent.putExtras(response);
+        ((Activity) appContext).setResult(Activity.RESULT_CANCELED, intent);
+        ((Activity) appContext).finish();
+      }
+    });
+    AlertDialog alertDialog = alert.create();
+    alertDialog.show();
   }
 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/wallet/DialogWalletInstall.java
@@ -53,8 +53,10 @@ public class DialogWalletInstall extends Dialog {
   private static String DIALOG_WALLET_INSTALL_BUTTON_CANCEL = "dialog_wallet_install_button_cancel";
   private static String APP_WALLET_INSTALL_WALLET_FROM_IAB = "app_wallet_install_wallet_from_iab";
   private static String DIALOG_WALLET_INSTALL_HAS_IMAGE = "dialog_wallet_install_has_image";
-  private static String DIALOG_NO_STORE_OR_BROWSER = "app_wallet_no_store_or_browser";
-  private static String APP_WALLET_SKIP = "app_wallet_skip";
+  private static String IAP_WALLET_AND_APPSTORE_NOT_INSTALLED_POPUP_BODY =
+      "iap_wallet_and_appstore_not_installed_popup_body";
+  private static String IAP_WALLET_AND_APPSTORE_NOT_INSTALLED_POPUP_BUTTON =
+      "iap_wallet_and_appstore_not_installed_popup_button";
 
   private Button dialog_wallet_install_button_cancel;
   private Button dialog_wallet_install_button_download;
@@ -242,10 +244,12 @@ public class DialogWalletInstall extends Dialog {
     AlertDialog.Builder alert = new AlertDialog.Builder(appContext);
     String value = appContext.getResources()
         .getString(appContext.getResources()
-            .getIdentifier(DIALOG_NO_STORE_OR_BROWSER, "string", appContext.getPackageName()));
+            .getIdentifier(IAP_WALLET_AND_APPSTORE_NOT_INSTALLED_POPUP_BODY, "string",
+                appContext.getPackageName()));
     String dismissValue = appContext.getResources()
         .getString(appContext.getResources()
-            .getIdentifier(APP_WALLET_SKIP, "string", appContext.getPackageName()));
+            .getIdentifier(IAP_WALLET_AND_APPSTORE_NOT_INSTALLED_POPUP_BUTTON, "string",
+                appContext.getPackageName()));
     alert.setMessage(value);
     alert.setCancelable(true);
     alert.setPositiveButton(dismissValue, new DialogInterface.OnClickListener() {

--- a/android-appcoins-billing/src/main/res/values/strings.xml
+++ b/android-appcoins-billing/src/main/res/values/strings.xml
@@ -5,5 +5,6 @@
     <string name="app_wallet_install_wallet_from_iab">To complete your purchase, you have to install an AppCoins wallet</string>
     <string name="app_wallet_skip">SKIP</string>
     <string name="app_wallet_wallet_missing">APPC Wallet missing</string>
-    <string name="app_wallet_no_store_or_browser">You need to install Aptoide to get AppCoins Wallet</string>
+    <string name="iap_wallet_and_appstore_not_installed_popup_body">You need the AppCoins Wallet to make this purchase. Download it from Aptoide or Play Store and come back to complete your purchase!</string>
+    <string name="iap_wallet_and_appstore_not_installed_popup_button">GOT IT!</string>
 </resources>

--- a/android-appcoins-billing/src/main/res/values/strings.xml
+++ b/android-appcoins-billing/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="app_wallet_install_wallet_from_iab">To complete your purchase, you have to install an AppCoins wallet</string>
     <string name="app_wallet_skip">SKIP</string>
     <string name="app_wallet_wallet_missing">APPC Wallet missing</string>
+    <string name="app_wallet_no_store_or_browser">You need to install Aptoide to get AppCoins Wallet</string>
 </resources>


### PR DESCRIPTION
**What does this PR do?**

   When there are no stores os browser available when you press to install the Appcoins Wallet, a popup with a warning.

**Database changed?**

   No

**Where should the reviewer start?**

DialogInstallWallet.java

**How should this be manually tested?**

Use a phone with no google play services , no Aptoide and no browser and try to make a purchase and install the wallet.

  Flow on how to test this or QA Tickets related to this use-case: [APPC-1518](https://aptoide.atlassian.net/browse/APPC-1518)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1518](https://aptoide.atlassian.net/browse/APPC-1518)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 
No



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass