### PR TITLE
Bugfix/problem with running getskudetails on main thread

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
@@ -97,7 +97,6 @@ public final class AppcoinsBillingStubHelper implements AppcoinsBilling, Seriali
 
   private void getSkuDetailsFromService(String packageName, String type, Bundle skusBundle,
       Bundle responseWs) {
-
     List<String> sku = skusBundle.getStringArrayList(Utils.GET_SKU_DETAILS_ITEM_LIST);
     ArrayList<SkuDetails> skuDetailsList = requestSkuDetails(sku, packageName, type);
     SkuDetailsResult skuDetailsResult = new SkuDetailsResult(skuDetailsList, 0);

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
@@ -77,7 +77,7 @@ public final class AppcoinsBillingStubHelper implements AppcoinsBilling, Seriali
       if (Looper.myLooper() == Looper.getMainLooper()) {
         Thread t = new Thread(new Runnable() {
           @Override public void run() {
-            sendSkuDetailsByFifty(packageName, type, skusBundle, responseWs);
+            getSkuDetailsFromService(packageName, type, skusBundle, responseWs);
             latch.countDown();
           }
         });
@@ -89,24 +89,24 @@ public final class AppcoinsBillingStubHelper implements AppcoinsBilling, Seriali
           responseWs.putInt(Utils.RESPONSE_CODE, ResponseCode.SERVICE_UNAVAILABLE.getValue());
         }
       } else {
-        sendSkuDetailsByFifty(packageName, type, skusBundle, responseWs);
+        getSkuDetailsFromService(packageName, type, skusBundle, responseWs);
       }
     }
     return responseWs;
   }
 
-  private void sendSkuDetailsByFifty(String packageName, String type, Bundle skusBundle,
+  private void getSkuDetailsFromService(String packageName, String type, Bundle skusBundle,
       Bundle responseWs) {
 
     List<String> sku = skusBundle.getStringArrayList(Utils.GET_SKU_DETAILS_ITEM_LIST);
-    ArrayList<SkuDetails> skuDetailsList = sendSkuDetailsByFifty(sku, packageName, type);
+    ArrayList<SkuDetails> skuDetailsList = requestSkuDetails(sku, packageName, type);
     SkuDetailsResult skuDetailsResult = new SkuDetailsResult(skuDetailsList, 0);
     responseWs.putInt(Utils.RESPONSE_CODE, 0);
     ArrayList<String> skuDetails = buildResponse(skuDetailsResult);
     responseWs.putStringArrayList("DETAILS_LIST", skuDetails);
   }
 
-  private ArrayList<SkuDetails> sendSkuDetailsByFifty(List<String> sku, String packageName,
+  private ArrayList<SkuDetails> requestSkuDetails(List<String> sku, String packageName,
       String type) {
     List <String> skuSendList = new ArrayList<>();
     ArrayList<SkuDetails> skuDetailsList = new ArrayList<>();

--- a/appcoins-billing/build.gradle
+++ b/appcoins-billing/build.gradle
@@ -36,7 +36,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.8.5'
 }
 
 //region Publishing

--- a/appcoins-billing/src/main/java/com/appcoins/sdk/billing/AppCoinsBilling.java
+++ b/appcoins-billing/src/main/java/com/appcoins/sdk/billing/AppCoinsBilling.java
@@ -50,7 +50,8 @@ public class AppCoinsBilling implements Billing {
       SkuDetailsResponseListener onSkuDetailsResponseListener) {
     SkuDetailsAsync skuDetailsAsync =
         new SkuDetailsAsync(skuDetailsParams, onSkuDetailsResponseListener, repository);
-    skuDetailsAsync.run();
+    Thread t = new Thread(skuDetailsAsync);
+    t.start();
   }
 
   @Override public void consumeAsync(String purchaseToken, ConsumeResponseListener listener) {

--- a/appcoins-billing/src/main/java/com/appcoins/sdk/billing/AppCoinsBilling.java
+++ b/appcoins-billing/src/main/java/com/appcoins/sdk/billing/AppCoinsBilling.java
@@ -50,8 +50,7 @@ public class AppCoinsBilling implements Billing {
       SkuDetailsResponseListener onSkuDetailsResponseListener) {
     SkuDetailsAsync skuDetailsAsync =
         new SkuDetailsAsync(skuDetailsParams, onSkuDetailsResponseListener, repository);
-    Thread t = new Thread(skuDetailsAsync);
-    t.start();
+    skuDetailsAsync.run();
   }
 
   @Override public void consumeAsync(String purchaseToken, ConsumeResponseListener listener) {

--- a/appcoins-billing/src/main/java/com/appcoins/sdk/billing/WSServiceController.java
+++ b/appcoins-billing/src/main/java/com/appcoins/sdk/billing/WSServiceController.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class WSServiceController {
 
-  public static String getSkuDetailsService(String url,String packageName, List<String> sku) {
+  public static String getSkuDetailsService(String url, String packageName, List<String> sku) {
     GetSkuDetailsService getSkuDetailsService = new GetSkuDetailsService(url, packageName, sku);
     return getSkuDetailsService.getSkuDetailsForPackageName();
   }

--- a/toolbox/src/main/java/com/asf/appcoins/toolbox/MainActivity.java
+++ b/toolbox/src/main/java/com/asf/appcoins/toolbox/MainActivity.java
@@ -129,22 +129,15 @@ public class MainActivity extends Activity {
     skusList.add("gas");
 
     skuDetailsParams.setMoreItemSkus(skusList);
-
-    Thread t = new Thread(new Runnable() {
-      @Override public void run() {
-        cab.querySkuDetailsAsync(skuDetailsParams, new SkuDetailsResponseListener() {
-          @Override
-          public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
-            Log.d(TAG, "responseCode: " + responseCode + "");
-            for (SkuDetails sd : skuDetailsList) {
-              Log.d(TAG, sd.toString());
-            }
-          }
-        });
+    cab.querySkuDetailsAsync(skuDetailsParams, new SkuDetailsResponseListener() {
+      @Override
+      public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
+        Log.d(TAG, "responseCode: " + responseCode + "");
+        for (SkuDetails sd : skuDetailsList) {
+          Log.d(TAG, sd.toString());
+        }
       }
     });
-
-    t.start();
   }
 
   public void makePaymentButtonClicked(View view) {


### PR DESCRIPTION
**What does this PR do?**

   Solves the problem of running network on main thread when accessing the SkuDetails from WS.

**Database changed?**

No

**Where should the reviewer start?**

AppcoinsBillingStubHelper.java

**How should this be manually tested?**

In toolbox remove the execution of the getSkuDetails from the interior of a thread.
Also in AppCoinsBilling from project Appcoins-Billing remove the thread from method that invokes the getSkuDetails.
Apply patch that does the previous changes.
[patch.zip](https://github.com/Aptoide/bds-sdk/files/3978281/patch.zip)

Compile and use try to obtain the skuDetails. 
  (https://aptoide.atlassian.net/browse/APPC-1553)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-1553](https://aptoide.atlassian.net/browse/APPC-1553)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 

No


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass