### PR TITLE
Bugfix/appc 2103 bugs reported from Flexion

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
@@ -133,6 +133,10 @@ public final class AppcoinsBillingStubHelper implements AppcoinsBilling, Seriali
         return startPayAsGuest(apiVersion, packageName, sku, type, developerPayloadObject, context);
       } else {
         if (WalletUtils.deviceSupportsWallet(Build.VERSION.SDK_INT)) {
+          skuDetails = getMappedSkuDetails(sku, packageName, type);
+          buyItemProperties =
+              new BuyItemProperties(apiVersion, packageName, sku, type, developerPayloadObject,
+                  skuDetails);
           intent = InstallDialogActivity.newIntent(context, buyItemProperties);
         } else {
           Bundle bundle = new Bundle();


### PR DESCRIPTION
**What does this PR do?**

   Fixes bug when the Intent for cafe bazar is created and the buyItemProperties contain Null values.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppcoinsBillingStubHellper.java

**How should this be manually tested?**

**Preconditions:**

1- Wallet is not installed

2- CafeBazaar is installed

3 - Device supports Wallet (Android SDK version >= 21)

**Flow.**

1 - Install toolbox

2 - Install Cafe Bazar

3 - Run toolbox

4 - Launch billing flow

5 - Check if Cafe Baza is open with no problems

  Flow on how to test this or QA Tickets related to this use-case: [APPC-2103](https://aptoide.atlassian.net/browse/APPC-2103)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APPC-2103](https://aptoide.atlassian.net/browse/APPC-2103)

**Questions:**

  No

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass